### PR TITLE
feat: 문제 및 테스트 케이스 기능 구현(생성, 수정, 삭제)

### DIFF
--- a/backend/src/main/java/com/shallwecode/backend/problem/application/dto/TestcaseReqDTO.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/application/dto/TestcaseReqDTO.java
@@ -4,16 +4,12 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
-
 @Getter
 @Setter
 @RequiredArgsConstructor
-public class ProblemReqDTO {
+public class TestcaseReqDTO {
 
-    private String title;
-    private String content;
-    private int problemLevel;
-    private List<TestcaseReqDTO> testcases;
+    private String input;
+    private String output;
 
 }

--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/aggregate/Problem.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/aggregate/Problem.java
@@ -3,16 +3,37 @@ package com.shallwecode.backend.problem.domain.aggregate;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Table(name = "problem")
 @Getter
 public class Problem {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long problemId;
+
     private String title;
     private String content;
     private int problemLevel;
+
+    @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Testcase> testCases = new ArrayList<>();
+
+    // 테스트 케이스 추가 메서드
+    public void addTestCase(Testcase testCase) {
+        testCases.add(testCase);
+        testCase.setProblem(this); // 양방향 연관 관계 설정
+    }
+
+    public void removeTestCase(Testcase testCase) {
+        testCases.remove(testCase);
+        testCase.setProblem(null);
+    }
+
+
 
     public void updateProblemTitle(String title) {
         this.title = title;

--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/aggregate/Testcase.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/aggregate/Testcase.java
@@ -10,7 +10,19 @@ public class Testcase {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long testcaseId;
-    private Long problemId;
+
     private String input;
     private String output;
+
+    @ManyToOne
+    @JoinColumn(name = "problem_id", nullable = false)
+    private Problem problem;
+
+    // 양방향 관계에서 Problem 엔티티와 연결을 설정하는 메서드
+    public void setProblem(Problem problem) {
+        this.problem = problem;
+    }
+
+
+
 }

--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/repository/TestcaseRepository.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/repository/TestcaseRepository.java
@@ -1,8 +1,11 @@
 package com.shallwecode.backend.problem.domain.repository;
 
+import com.shallwecode.backend.problem.domain.aggregate.Problem;
 import com.shallwecode.backend.problem.domain.aggregate.Testcase;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TestcaseRepository extends JpaRepository<Testcase, Long> {
 
+    // 특정 problemId에 해당하는 모든 테스트 케이스 삭제
+    void deleteByProblem_ProblemId(Long id);
 }

--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/service/ProblemDomainService.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/service/ProblemDomainService.java
@@ -3,7 +3,9 @@ package com.shallwecode.backend.problem.domain.service;
 import com.shallwecode.backend.problem.application.dto.ProblemReqDTO;
 import com.shallwecode.backend.problem.application.dto.ProblemResDTO;
 import com.shallwecode.backend.problem.domain.aggregate.Problem;
+import com.shallwecode.backend.problem.domain.aggregate.Testcase;
 import com.shallwecode.backend.problem.domain.repository.ProblemRepository;
+import com.shallwecode.backend.problem.domain.repository.TestcaseRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
@@ -14,26 +16,50 @@ import org.springframework.stereotype.Service;
 public class ProblemDomainService {
 
     private final ProblemRepository repository;
+    private final TestcaseRepository testCaseRepository;
     private final ModelMapper modelMapper;
 
     @Transactional
     public void saveProblem(ProblemReqDTO newProblem) {
-        repository.save(modelMapper.map(newProblem, Problem.class));
+
+        Problem problem = modelMapper.map(newProblem, Problem.class);
+        repository.save(problem);
+
+        // 연관된 테스트 케이스 저장
+        newProblem.getTestcases().forEach(testcaseReqDTO -> {
+            Testcase testcase = modelMapper.map(testcaseReqDTO, Testcase.class);
+            testcase.setProblem(problem); // 문제와 테스트 케이스 연결
+            testCaseRepository.save(testcase);
+        });
+
     }
 
     @Transactional
     public void updateProblem(Long id, ProblemReqDTO updateProblem) {
 
+        // 문제를 조회하고 제목, 내용, 난이도 업데이트
         Problem foundProblem = repository.findById(id)
                 .orElseThrow(() -> new RuntimeException("해당 id에 맞는 문제가 존재하지 않습니다."));
         foundProblem.updateProblemTitle(updateProblem.getTitle());
         foundProblem.updateProblemContent(updateProblem.getContent());
         foundProblem.updateProblemProblemLevel(updateProblem.getProblemLevel());
 
+        // 기존 테스트 케이스 삭제 후 새로운 테스트 케이스 추가
+        testCaseRepository.deleteByProblem_ProblemId(id);
+        updateProblem.getTestcases().forEach(testcaseReqDTO -> {
+            Testcase testcase = modelMapper.map(testcaseReqDTO, Testcase.class);
+            testcase.setProblem(foundProblem); // 문제와 테스트 케이스 연결 설정
+            testCaseRepository.save(testcase);
+        });
+
+
     }
 
     @Transactional
     public void deleteProblem(Long problemId) {
+
+        // 문제와 연관된 테스트 케이스 모두 삭제 후 문제 삭제
+        testCaseRepository.deleteById(problemId);
         repository.deleteById(problemId);
     }
 


### PR DESCRIPTION
🌟개요
---


🌐연결된 Issues
---
close #21 

📋작업사항
--- 문제 생성시 해당 문제의 테스트케이스도  같이 생성할 수 있도록 기능을 구현
--- 문제 수정시 테스트 케이스도 수정 가능
--- 문제 삭제시 문제와 연결된 테스크 케이스도 모두 삭제되도록 구현
--- JPA의 양방향 관계 매핑을 사용했음.

이슈 번호가 #21인데 브랜치명 번호는 #6으로 잘못 기재
