### PR TITLE
fix: Problem 및 Testcase 사이의 관계를 양방향 매핑에서 단방향 매핑으로 수정

### DIFF
--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/aggregate/Problem.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/aggregate/Problem.java
@@ -3,9 +3,6 @@ package com.shallwecode.backend.problem.domain.aggregate;
 import jakarta.persistence.*;
 import lombok.Getter;
 
-import java.util.ArrayList;
-import java.util.List;
-
 @Entity
 @Table(name = "problem")
 @Getter
@@ -19,22 +16,6 @@ public class Problem {
     private String content;
     private int problemLevel;
 
-    @OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Testcase> testCases = new ArrayList<>();
-
-    // 테스트 케이스 추가 메서드
-    public void addTestCase(Testcase testCase) {
-        testCases.add(testCase);
-        testCase.setProblem(this); // 양방향 연관 관계 설정
-    }
-
-    public void removeTestCase(Testcase testCase) {
-        testCases.remove(testCase);
-        testCase.setProblem(null);
-    }
-
-
-
     public void updateProblemTitle(String title) {
         this.title = title;
     }
@@ -46,7 +27,5 @@ public class Problem {
     public void updateProblemProblemLevel(int problemLevel) {
         this.problemLevel = problemLevel;
     }
-
-
 
 }

--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/aggregate/Testcase.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/aggregate/Testcase.java
@@ -14,15 +14,10 @@ public class Testcase {
     private String input;
     private String output;
 
-    @ManyToOne
-    @JoinColumn(name = "problem_id", nullable = false)
-    private Problem problem;
+    private Long problemId;
 
-    // 양방향 관계에서 Problem 엔티티와 연결을 설정하는 메서드
-    public void setProblem(Problem problem) {
-        this.problem = problem;
+    public void updateProblemId(Long problemId) {
+        this.problemId = problemId;
     }
-
-
 
 }

--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/repository/TestcaseRepository.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/repository/TestcaseRepository.java
@@ -1,11 +1,10 @@
 package com.shallwecode.backend.problem.domain.repository;
 
-import com.shallwecode.backend.problem.domain.aggregate.Problem;
 import com.shallwecode.backend.problem.domain.aggregate.Testcase;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TestcaseRepository extends JpaRepository<Testcase, Long> {
 
     // 특정 problemId에 해당하는 모든 테스트 케이스 삭제
-    void deleteByProblem_ProblemId(Long id);
+    void deleteByProblemId(Long id);
 }

--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/service/ProblemDomainService.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/service/ProblemDomainService.java
@@ -1,7 +1,6 @@
 package com.shallwecode.backend.problem.domain.service;
 
 import com.shallwecode.backend.problem.application.dto.ProblemReqDTO;
-import com.shallwecode.backend.problem.application.dto.ProblemResDTO;
 import com.shallwecode.backend.problem.domain.aggregate.Problem;
 import com.shallwecode.backend.problem.domain.aggregate.Testcase;
 import com.shallwecode.backend.problem.domain.repository.ProblemRepository;
@@ -28,7 +27,7 @@ public class ProblemDomainService {
         // 연관된 테스트 케이스 저장
         newProblem.getTestcases().forEach(testcaseReqDTO -> {
             Testcase testcase = modelMapper.map(testcaseReqDTO, Testcase.class);
-            testcase.setProblem(problem); // 문제와 테스트 케이스 연결
+            testcase.updateProblemId(problem.getProblemId()); // 문제 ID 설정
             testCaseRepository.save(testcase);
         });
 
@@ -45,13 +44,12 @@ public class ProblemDomainService {
         foundProblem.updateProblemProblemLevel(updateProblem.getProblemLevel());
 
         // 기존 테스트 케이스 삭제 후 새로운 테스트 케이스 추가
-        testCaseRepository.deleteByProblem_ProblemId(id);
+        testCaseRepository.deleteByProblemId(id);
         updateProblem.getTestcases().forEach(testcaseReqDTO -> {
             Testcase testcase = modelMapper.map(testcaseReqDTO, Testcase.class);
-            testcase.setProblem(foundProblem); // 문제와 테스트 케이스 연결 설정
+            testcase.updateProblemId(foundProblem.getProblemId()); // 문제 ID 설정
             testCaseRepository.save(testcase);
         });
-
 
     }
 
@@ -62,8 +60,5 @@ public class ProblemDomainService {
         testCaseRepository.deleteById(problemId);
         repository.deleteById(problemId);
     }
-
-
-
 
 }


### PR DESCRIPTION
🌟개요
QueryDSL를 사용한 문제 및 테스트 케이스 조회시 Entity간의 양방향 매핑으로 인해 조회가 잘 되지 않는다는 
희순님의 피드백을 반영해 단방향 매핑으로 수정했습니다.

📋작업사항
--- Testcase 엔티티에 problemId 외래키 속성 추가
--- 수정된 엔티티에 맞게 코드 서비스 코드 및 테스트케이스에서의 JPA delete 메소드 수정

