### PR TITLE
feat: 문제 수정, 삭제 & 관리자 유저 조회, 삭제 기능 구현

### DIFF
--- a/backend/src/main/java/com/shallwecode/backend/problem/application/controller/ProblemController.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/application/controller/ProblemController.java
@@ -71,11 +71,10 @@ public class ProblemController {
             description = "관리자가 문제를 상세 조회하는 기능입니다."
     )
     @GetMapping("/{problemId}")
-    public ResponseEntity<List<ProblemOneResDTO>> selectProblem(@PathVariable Long problemId) {
+    public ResponseEntity<ProblemOneResDTO> selectProblem(@PathVariable Long problemId) {
 
         /* 데이터 조회 */
-        List<ProblemOneResDTO> oneProblem = problemService.selectOneProblem(problemId);
-
+        ProblemOneResDTO oneProblem = problemService.selectOneProblem(problemId);
         return ResponseEntity.ok().body(oneProblem);
     }
 

--- a/backend/src/main/java/com/shallwecode/backend/problem/application/dto/ProblemOneResDTO.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/application/dto/ProblemOneResDTO.java
@@ -7,13 +7,21 @@ import java.util.List;
 @Getter
 @Setter
 @ToString
-@AllArgsConstructor
 public class ProblemOneResDTO {
     private Long problemId;
     private String title;
     private String content;
     private int problemLevel;
-    private Long testcaseId;
-    private String input;
-    private String output;
+    private List<TestcaseDTO> testcases;
+
+    // QueryDSL용 생성자 추가
+    public ProblemOneResDTO(Long problemId, String title, String content, int problemLevel) {
+        this.problemId = problemId;
+        this.title = title;
+        this.content = content;
+        this.problemLevel = problemLevel;
+    }
+//    private Long testcaseId;
+//    private String input;
+//    private String output;
 }

--- a/backend/src/main/java/com/shallwecode/backend/problem/application/dto/ProblemReqDTO.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/application/dto/ProblemReqDTO.java
@@ -14,6 +14,6 @@ public class ProblemReqDTO {
     private String title;
     private String content;
     private int problemLevel;
-    private List<TestcaseReqDTO> testcases;
+    private List<TestcaseDTO> testcases;
 
 }

--- a/backend/src/main/java/com/shallwecode/backend/problem/application/dto/TestcaseDTO.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/application/dto/TestcaseDTO.java
@@ -1,5 +1,6 @@
 package com.shallwecode.backend.problem.application.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -7,7 +8,8 @@ import lombok.Setter;
 @Getter
 @Setter
 @RequiredArgsConstructor
-public class TestcaseReqDTO {
+@AllArgsConstructor
+public class TestcaseDTO {
 
     private String input;
     private String output;

--- a/backend/src/main/java/com/shallwecode/backend/problem/application/service/ProblemService.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/application/service/ProblemService.java
@@ -25,7 +25,7 @@ public class ProblemService {
         return problemDomainService.findAllMyProblem(userId);
     }
 
-    public List<ProblemOneResDTO> selectOneProblem(Long problemId) {
+    public ProblemOneResDTO selectOneProblem(Long problemId) {
         return problemDomainService.selectOneProblem(problemId);
     }
 

--- a/backend/src/main/java/com/shallwecode/backend/user/application/controller/UserController.java
+++ b/backend/src/main/java/com/shallwecode/backend/user/application/controller/UserController.java
@@ -1,10 +1,7 @@
 package com.shallwecode.backend.user.application.controller;
 
 import com.shallwecode.backend.common.util.CustomUserUtils;
-import com.shallwecode.backend.user.application.dto.user.FindUserListDTO;
-import com.shallwecode.backend.user.application.dto.user.FindUserDetailDTO;
-import com.shallwecode.backend.user.application.dto.user.UserSaveDTO;
-import com.shallwecode.backend.user.application.dto.user.UserUpdateDTO;
+import com.shallwecode.backend.user.application.dto.user.*;
 import com.shallwecode.backend.user.application.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -69,6 +66,16 @@ public class UserController {
         List<FindUserDetailDTO> userList = userService.findUserDetailsByNickname(nickname);
         return ResponseEntity.ok(userList);
     }
+
+    // 관리자 회원 조회
+    @GetMapping("/admin")
+    @Operation(summary = "관리자 회원 목록 조회", description = "회원 목록을 조회한다.")
+    public ResponseEntity<List<FindUserInfoDTO>> getAllUserInfo(@RequestParam(defaultValue = "", required = false) String nickname) {
+
+        List<FindUserInfoDTO> userList = userService.findUserInfoByNickname(nickname);
+        return ResponseEntity.ok(userList);
+    }
+
 
     @GetMapping("/list")
     @Operation(summary = "회원 목록 조회", description = "친구 신청을 할 수 있는 회원을 조회한다.")

--- a/backend/src/main/java/com/shallwecode/backend/user/application/dto/user/FindUserInfoDTO.java
+++ b/backend/src/main/java/com/shallwecode/backend/user/application/dto/user/FindUserInfoDTO.java
@@ -1,0 +1,22 @@
+package com.shallwecode.backend.user.application.dto.user;
+
+import com.shallwecode.backend.user.domain.aggregate.SocialType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindUserInfoDTO {
+
+    private Long userId;
+    private String email;
+    private SocialType provider;
+    private String nickname;
+    private LocalDateTime createdAt;
+
+}

--- a/backend/src/main/java/com/shallwecode/backend/user/application/service/UserService.java
+++ b/backend/src/main/java/com/shallwecode/backend/user/application/service/UserService.java
@@ -82,6 +82,13 @@ public class UserService implements UserDetailsService {
         return userDetailList;
     }
 
+    // 닉네임으로 관리자 회원 목록 조회
+    @Transactional(readOnly = true)
+    public List<FindUserInfoDTO> findUserInfoByNickname(String nickname) {
+        return userDomainService.findAllInfoUsers(nickname);
+    }
+
+
     public FindUserDetailDTO findUserDetail(Long loginUserId) {
 
         Long allProblemCnt = userDomainService.findAllProblemCnt();

--- a/backend/src/main/java/com/shallwecode/backend/user/domain/service/UserDomainService.java
+++ b/backend/src/main/java/com/shallwecode/backend/user/domain/service/UserDomainService.java
@@ -7,11 +7,7 @@ import com.shallwecode.backend.common.exception.CustomException;
 import com.shallwecode.backend.common.exception.ErrorCode;
 import com.shallwecode.backend.problem.domain.aggregate.QProblem;
 import com.shallwecode.backend.problem.domain.aggregate.QTry;
-import com.shallwecode.backend.user.application.dto.user.FindUserListDTO;
-import com.shallwecode.backend.user.application.dto.user.FindUserDTO;
-import com.shallwecode.backend.user.application.dto.user.FindUserDetailDTO;
-import com.shallwecode.backend.user.application.dto.user.UserSaveDTO;
-import com.shallwecode.backend.user.application.dto.user.UserUpdateDTO;
+import com.shallwecode.backend.user.application.dto.user.*;
 import com.shallwecode.backend.user.domain.aggregate.FriendStatus;
 import com.shallwecode.backend.user.domain.aggregate.QFriend;
 import com.shallwecode.backend.user.domain.aggregate.QUserInfo;
@@ -159,4 +155,21 @@ public class UserDomainService {
                 .where(userInfo.nickname.containsIgnoreCase(nickname.trim()))
                 .fetch();
     }
+
+
+    public List<FindUserInfoDTO> findAllInfoUsers(String nickname) {
+        QUserInfo userInfo = QUserInfo.userInfo;
+
+        return jpaQueryFactory
+                .select(Projections.constructor(FindUserInfoDTO.class,
+                        userInfo.userId,
+                        userInfo.email,
+                        userInfo.provider,
+                        userInfo.nickname,
+                        userInfo.createdAt))
+                .from(userInfo)
+                .where(userInfo.nickname.containsIgnoreCase(nickname.trim()))
+                .fetch();
+    }
+
 }

--- a/frontend/src/components/admin/ProbListComponent.vue
+++ b/frontend/src/components/admin/ProbListComponent.vue
@@ -5,6 +5,7 @@ import PageBar from "@/components/admin/PageBar.vue";
 import {onMounted, ref} from "vue";
 import axios from "axios";
 import router from "@/router/index.js";
+import {useAuthStore} from "@/stores/auth.js";
 
 const problemList = ref([]);
 const currentPage = ref(0);
@@ -13,13 +14,13 @@ const totalItems = ref(0);
 const keyword = ref('');
 const option = ref('');
 
-const token = ref('');
+const authStore = useAuthStore();
 
 const fetchProblemList = async (page = 1) => {
   try {
-    const response = await axios.get(`http://localhost:8080/api/v1/problem/adminList`, {
+    const response = await axios.get(`http://localhost:8080/api/v1/problem/admin`, {
       headers: {
-        Authorization: `Bearer ${token.value}`
+        Authorization: `Bearer ${authStore.accessToken}`
       },
       params: {
         page,
@@ -60,9 +61,21 @@ const handleEditProblem = (problemId) => {
 
 
 // 문제 삭제 처리 함수
-const handleDeleteProblem = (problemId) => {
-  console.log('삭제할 문제 ID:', problemId);
-  // 삭제 로직을 추가하세요
+const handleDeleteProblem = async (problemId) => {
+
+  try {
+    await axios.delete(`http://localhost:8080/api/v1/problem/${problemId}`, {
+      headers: {
+        Authorization: `Bearer ${authStore.accessToken}`,
+      },
+    });
+    console.log('문제가 삭제되었습니다:', problemId);
+    await fetchProblemList(currentPage.value); // 페이지를 새로고침하여 목록 업데이트
+  } catch (error) {
+    console.error('문제 삭제 중 오류가 발생했습니다.', error);
+    alert('문제 삭제에 실패했습니다.');
+  }
+
 };
 
 

--- a/frontend/src/components/admin/ProbSaveComponent.vue
+++ b/frontend/src/components/admin/ProbSaveComponent.vue
@@ -4,7 +4,7 @@
 
     <div class="form-group">
       <label for="title">제목</label>
-      <input type="text" id="title" v-model="title" placeholder="이번 문제는 누구 풀까?" />
+      <input type="text" id="title" v-model="title" placeholder="문제 제목을 입력해 주세요" />
     </div>
 
     <div class="form-group">
@@ -18,6 +18,8 @@
         <option value="1">Lv.1</option>
         <option value=2>Lv.2</option>
         <option value=3>Lv.3</option>
+        <option value=4>Lv.4</option>
+        <option value=5>Lv.5</option>
       </select>
     </div>
 
@@ -51,9 +53,13 @@
 import { ref } from "vue";
 import axios from "axios";
 import {useRouter} from "vue-router";
+import {useAuthStore} from "@/stores/auth.js";
+
 
 export default {
   setup() {
+
+    const authStore = useAuthStore();
 
     const router = useRouter(); // 라우터 이동 설정
 
@@ -91,10 +97,13 @@ export default {
 
 
       try {
-        // 서버에 POST 요청 보내기
-        // 추후 토큰에 관리자 인증 정보 추가해야 함
-        const response = await axios.post('http://localhost:8080/api/v1/problem', formData);
-        console.log('가게가 성공적으로 등록되었습니다:',response.data);
+        const response = await axios.post('http://localhost:8080/api/v1/problem', formData,{
+          headers: {
+            Authorization: `Bearer ${authStore.accessToken}`,
+            'Authorization-refresh': `Bearer ${authStore.refreshToken}`
+          }
+        });
+        console.log('문제가 성공적으로 등록되었습니다:',response.data);
         await router.push('/admin');
       } catch (error){
         console.error('문제 등록 중 오류가 발생했습니다:', error);

--- a/frontend/src/components/admin/UserListComponent.vue
+++ b/frontend/src/components/admin/UserListComponent.vue
@@ -1,21 +1,47 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
 import axios from "axios";
+import {useAuthStore} from "@/stores/auth.js";
+
+const authStore = useAuthStore();
 
 const currentUserPage = ref(1);
 const ROWS_PER_PAGE = 7;
 const searchQuery = ref('');
-
 const users = ref([]);
 
 const fetchUserList = async () => {
   try {
-    const response = await axios.get('http://localhost:8080/api/v1/user');
+    const response = await axios.get('http://localhost:8080/api/v1/user/admin', {
+      headers: {
+        Authorization: `Bearer ${authStore.accessToken}`
+      }
+    });
     users.value = response.data;
   } catch (error) {
     console.error('회원 목록을 불러오는 중 에러가 발생했습니다.', error.response ? error.response.data : error.message);
   }
 };
+
+// 사용자 삭제 함수
+const deleteUser = async (userId) => {
+  const confirmed = confirm("해당 사용자를 삭제하시겠습니까?");
+  if (!confirmed) return;
+
+  try {
+    await axios.delete(`http://localhost:8080/api/v1/user/${userId}`, {
+      headers: {
+        Authorization: `Bearer ${authStore.accessToken}`
+      }
+    });
+    // 삭제 성공 후 사용자 목록을 다시 로드
+    await fetchUserList();
+  } catch (error) {
+    console.error('사용자 삭제 중 오류가 발생했습니다.', error.response ? error.response.data : error.message);
+  }
+};
+
+
 
 const displayedUsers = computed(() => {
   const startIdx = (currentUserPage.value - 1) * ROWS_PER_PAGE;


### PR DESCRIPTION
🌟개요
---

🌐연결된 Issues
#131 

📋작업사항
---  관리자 문제 수정, 삭제 기능을 프론트에서 구현했습니다.
---  요청시 헤더에 인증 토큰을 전달하도록 추가했습니다.
---  문제 수정시 기존의 문제 정보를 불러오기 위해서 문제 단일 조회 Controller, DTO, Service 코드를 수정했습니다.
---  이제 문제 조회시 테스트 케이스가 문제 안에 배열로 감싸져서 단일 객체로 조회됩니다.
---  관리자 유저 정보 조회를 위해서 Controller, DTO, Service 코드를 추가했습니다.
---  관리자가 유저 정보 조회시 관리자 권한이 맞는지 확인하는 로직이 누락되서 추가할 예정입니다.
--- 유저 정보 삭제 버튼은 구현했으나, 외래키 참조 문제가 발생해서 현재 수정 중입니다.

 


