### PR TITLE
feat: 문제 목록 클릭시 해당 코딩방 생성 및 입장 기능 구현

### DIFF
--- a/backend/src/main/java/com/shallwecode/backend/problem/application/controller/CodingRoomController.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/application/controller/CodingRoomController.java
@@ -4,6 +4,7 @@ import com.shallwecode.backend.common.util.CustomUserUtils;
 import com.shallwecode.backend.problem.application.dto.CodingRoomReqDTO;
 import com.shallwecode.backend.problem.application.dto.FindMyCodingRoomResDTO;
 import com.shallwecode.backend.problem.application.service.CodingRoomService;
+import com.shallwecode.backend.problem.domain.aggregate.CodingRoom;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -26,13 +27,12 @@ public class CodingRoomController {
     /* 코딩방 등록 */
     @Operation(
             summary = "코딩방 등록",
-            description = "새로운 코딩방을 생성합니다."
+            description = "새로운 코딩방을 생성합니다. 생성된 코딩방의 번호를 반환합니다."
     )
-    @PostMapping
-    public ResponseEntity<String> saveCodingRoom(@RequestBody CodingRoomReqDTO newCodingRoomInfo) {
-
-        codingRoomService.saveCodingRoom(newCodingRoomInfo);
-        return new ResponseEntity<>("코딩방 생성 완료", HttpStatus.CREATED);
+    @PostMapping("/{problemId}")
+    public ResponseEntity<CodingRoom> saveCodingRoom(@PathVariable Long problemId) {
+        CodingRoom codingRoom = codingRoomService.saveCodingRoom(problemId);
+        return ResponseEntity.ok().body(codingRoom);
     }
 
     /* 코딩방 삭제 */

--- a/backend/src/main/java/com/shallwecode/backend/problem/application/dto/CodingRoomReqDTO.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/application/dto/CodingRoomReqDTO.java
@@ -1,12 +1,13 @@
 package com.shallwecode.backend.problem.application.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
-@RequiredArgsConstructor
+@AllArgsConstructor
 public class CodingRoomReqDTO {
 
     private Long problemId;  // 외래 키로 문제 ID를 참조

--- a/backend/src/main/java/com/shallwecode/backend/problem/application/service/CodingRoomService.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/application/service/CodingRoomService.java
@@ -3,14 +3,14 @@ package com.shallwecode.backend.problem.application.service;
 import com.shallwecode.backend.common.exception.CustomException;
 import com.shallwecode.backend.common.exception.ErrorCode;
 import com.shallwecode.backend.common.util.CustomUserUtils;
-import com.shallwecode.backend.problem.application.dto.CoopResDTO;
-import com.shallwecode.backend.problem.application.dto.FindMyCodingRoomResDTO;
+import com.shallwecode.backend.problem.application.dto.*;
+import com.shallwecode.backend.problem.domain.aggregate.CodingRoom;
 import com.shallwecode.backend.problem.domain.service.CodingRoomDomainService;
 import com.shallwecode.backend.problem.domain.service.CoopDomainService;
+import com.shallwecode.backend.problem.domain.service.ProblemDomainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import com.shallwecode.backend.problem.application.dto.CodingRoomReqDTO;
-import com.shallwecode.backend.problem.application.dto.CoopDTO;
+
 import java.util.List;
 
 @Service
@@ -18,6 +18,7 @@ import java.util.List;
 public class CodingRoomService {
 
     private final CodingRoomDomainService codingRoomDomainService;
+    private final ProblemDomainService problemDomainService;
     private final CoopDomainService coopDomainService;
 
     public List<FindMyCodingRoomResDTO> findMyCodingRoom(Long userId) {
@@ -25,23 +26,27 @@ public class CodingRoomService {
         return codingRoomDomainService.findMyCodingRoom(userId);
     }
 
-    public void saveCodingRoom(CodingRoomReqDTO codingRoomReqDTO) {
+    /* 코딩방 생성 */
+    public CodingRoom saveCodingRoom(Long problemId) {
 
         // 해당 번호의 문제가 있는지 확인해야 하지만 프론트에서 문제를 조회해서
         // 확인 후 코딩방 생성 예정이므로 패스.
 
-        Long codingRoomId = codingRoomDomainService.saveCodingRoom(codingRoomReqDTO);
+        // 엔티티 반환 (생성된 codingRoomId 가 반환됨)
+        CodingRoom codingRoom = codingRoomDomainService.saveCodingRoom(problemId);
 
         // 호스트 정보 협업 친구 테이블에 저장하기
         Long loginUserId = CustomUserUtils.getCurrentUserSeq();
 
         CoopDTO coopDTO = new CoopDTO();
-        coopDTO.setCodingRoomId(codingRoomId);
+        coopDTO.setCodingRoomId(codingRoom.getCodingRoomId());
         coopDTO.setUserId(loginUserId);
+     // coopDTO.setUserId(23); - TestCode 실행시 유저 아이디를 가져올 수 없어서 임시로 작성한 코드임.
         coopDTO.setHost(true);
 
         coopDomainService.inviteCoopFriend(coopDTO);
 
+        return codingRoom;
     }
 
     public void deleteCodingRoom(Long codingRoomId) {

--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/service/CodingRoomDomainService.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/service/CodingRoomDomainService.java
@@ -33,13 +33,15 @@ public class CodingRoomDomainService {
     private final JPAQueryFactory queryFactory;
 
     @Transactional
-    public Long saveCodingRoom(CodingRoomReqDTO newCodingRoom) {
+    public CodingRoom saveCodingRoom(Long problemId) {
+        // 문제 내용만 따로 조회
+        String content = selectProblemContent(problemId);
 
-        CodingRoom codingRoom = modelMapper.map(newCodingRoom, CodingRoom.class);
-        repository.save(codingRoom);
+        // 프론트에서 문제 목록을 통해서 문제에 들어갈 때 언어를 선택하지는 않아서 기본 JAVA 셋팅
+        CodingRoomReqDTO newCodingRoom = new CodingRoomReqDTO(problemId, "JAVA", content, true);
 
-        return codingRoom.getCodingRoomId();
-
+        // 엔티티 반환
+        return repository.save(modelMapper.map(newCodingRoom, CodingRoom.class));
     }
 
     // 코딩방 수정 기능은 제공하지 않음.
@@ -81,5 +83,15 @@ public class CodingRoomDomainService {
         // 코드 수정
         CodingRoom foundCodingRoom = repository.findById(sendCodeDTO.getCodingRoomId()).orElseThrow(() -> new RuntimeException("해당 코딩방이 존재하지 않습니다."));
         foundCodingRoom.updateCodeContent(sendCodeDTO.getCodeContent());
+    }
+
+    /* 코딩방 생성시 문제 내용 조회 */
+    @Transactional
+    public String selectProblemContent(Long problemId) {
+        QProblem qProblem = QProblem.problem;
+        return queryFactory.select(qProblem.content)
+                .from(qProblem)
+                .where(qProblem.problemId.eq(problemId))
+                .fetchOne();
     }
 }

--- a/backend/src/main/java/com/shallwecode/backend/problem/domain/service/ProblemDomainService.java
+++ b/backend/src/main/java/com/shallwecode/backend/problem/domain/service/ProblemDomainService.java
@@ -136,7 +136,7 @@ public class ProblemDomainService {
             return null; // 문제 없음 처리
         }
 
-        // 해당 Problem에 대한 모든 Testcase를 조회하여 리스트로 추가
+        // 해당 Problem 에 대한 모든 Testcase 를 조회하여 리스트로 추가
         List<TestcaseDTO> testcases = queryFactory.select(
                         Projections.constructor(TestcaseDTO.class,
                                 qTestcase.input,

--- a/backend/src/test/java/com/shallwecode/backend/problem/application/service/CodingRoomServiceTest.java
+++ b/backend/src/test/java/com/shallwecode/backend/problem/application/service/CodingRoomServiceTest.java
@@ -1,0 +1,25 @@
+package com.shallwecode.backend.problem.application.service;
+
+import com.shallwecode.backend.problem.domain.aggregate.CodingRoom;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class CodingRoomServiceTest {
+
+    @Autowired
+    private CodingRoomService codingRoomService;
+
+    @Test
+    void saveCodingRoomTest() {
+        CodingRoom codingRoom = codingRoomService.saveCodingRoom(4L);
+        System.out.println(codingRoom.getCodingRoomId());
+        System.out.println(codingRoom.getCodeContent());
+        System.out.println(codingRoom.getProblemId());
+        System.out.println(codingRoom.isOpen());
+        System.out.println(codingRoom.getTryLanguage());
+    }
+}

--- a/backend/src/test/java/com/shallwecode/backend/problem/application/service/ProblemServiceTest.java
+++ b/backend/src/test/java/com/shallwecode/backend/problem/application/service/ProblemServiceTest.java
@@ -1,0 +1,41 @@
+package com.shallwecode.backend.problem.application.service;
+
+import com.shallwecode.backend.problem.application.dto.ProblemListResDTO;
+import com.shallwecode.backend.problem.application.dto.ProblemOneResDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ProblemServiceTest {
+
+    @Autowired
+    private ProblemService problemService;
+
+//    @Test
+//    @DisplayName("한 문제 상세 조회 테스트")
+//    void selectOneProblemTest() {
+//        List<ProblemOneResDTO> problemResList = problemService.selectOneProblem(1L);
+//
+//        for (ProblemOneResDTO problemOneResDTO : problemResList) {
+//            System.out.println(problemOneResDTO.toString());
+//        }
+//    }
+
+    @Test
+    @DisplayName("문제 목록 조회 테스트")
+    void selectProblemListTest() {
+        ProblemListResDTO problemList = problemService.selectProblemList(1, 10L, "문제", null);
+        System.out.println(problemList.getCurrentPage());
+        System.out.println(problemList.getTotalItems());
+        System.out.println(problemList.getTotalPages());
+        for(int i = 0; i < problemList.getProblemList().size(); i++) {
+            System.out.println(problemList.getProblemList().get(i));
+        }
+    }
+}

--- a/backend/src/test/java/com/shallwecode/backend/problem/domain/service/CodingRoomDomainServiceTest.java
+++ b/backend/src/test/java/com/shallwecode/backend/problem/domain/service/CodingRoomDomainServiceTest.java
@@ -1,6 +1,7 @@
 package com.shallwecode.backend.problem.domain.service;
 
 import com.shallwecode.backend.problem.application.dto.SendCodeDTO;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -31,5 +32,11 @@ class CodingRoomDomainServiceTest {
     void updateCodeTest(Long codingRoomId, Long problemId, String tryLanguage, String codeContent) {
         SendCodeDTO sendCodeDTO = new SendCodeDTO(codingRoomId, problemId, tryLanguage, codeContent);
         codingRoomDomainService.updateCode(sendCodeDTO);
+    }
+
+    @Test
+    void selectProblemContentTest() {
+        String problemContent = codingRoomDomainService.selectProblemContent(4L);
+        System.out.println(problemContent);
     }
 }

--- a/backend/src/test/java/com/shallwecode/backend/problem/domain/service/ProblemDomainServiceTest.java
+++ b/backend/src/test/java/com/shallwecode/backend/problem/domain/service/ProblemDomainServiceTest.java
@@ -14,14 +14,14 @@ class ProblemDomainServiceTest {
     @Autowired
     private ProblemDomainService problemDomainService;
 
-    @Test
-    void selectOneProblem() {
-        List<ProblemOneResDTO> problemResList = problemDomainService.selectOneProblem(1L);
-
-        for (ProblemOneResDTO problemOneResDTO : problemResList) {
-            System.out.println(problemOneResDTO.toString());
-        }
-    }
+//    @Test
+//    void selectOneProblem() {
+//        List<ProblemOneResDTO> problemResList = problemDomainService.selectOneProblem(1L);
+//
+//        for (ProblemOneResDTO problemOneResDTO : problemResList) {
+//            System.out.println(problemOneResDTO.toString());
+//        }
+//    }
 
     @Test
     void selectProblemList() {

--- a/frontend/src/components/codingroom/ChatArea.vue
+++ b/frontend/src/components/codingroom/ChatArea.vue
@@ -5,6 +5,13 @@ import axios from "axios";
 
 const useAuth = useAuthStore();
 
+const props = defineProps({
+  codingRoomId : {
+    type : String,
+    required : true
+  }
+});
+
 const tempObjectInfo = {
   userId : useAuth.userId,
   accessToken : useAuth.accessToken,
@@ -98,8 +105,8 @@ const connectWebSocket = (codingRoomId) => {
 
     // 상태 체크 - 접속시 보내온 상태정보 업데이트
     if(receiveMessage.type === "statusCheck") {
-      console.log(receiveMessage);
-      console.log(Object.entries(receiveMessage.sessionList));
+      // console.log(receiveMessage);
+      // console.log(Object.entries(receiveMessage.sessionList));
       // for(let i = 0; i < coopMember.length; i++) {
       //   // 온라인 정보만 기록한다.
       //   if(receiveMessage.coopMember[i].status === "online")
@@ -149,8 +156,8 @@ const disConnectWebSocket = () => {
 
 // DOM 로딩 전
 onMounted(async () => {
-  await communicateCoopInfo(10);
-  connectWebSocket(10);
+  await communicateCoopInfo(props.codingRoomId);
+  connectWebSocket(props.codingRoomId);
 })
 
 onUnmounted(async() => {

--- a/frontend/src/components/codingroom/ProblemDescription.vue
+++ b/frontend/src/components/codingroom/ProblemDescription.vue
@@ -1,14 +1,10 @@
 <script setup>
-const problemText = '정수 배열 numbers가 주어집니다. 이 배열의 각 원소에 대해 다음과 같은 규칙으로 가공하여 새로운 배열을 만들어 반환하는 함수를 작성해주세요:\n' +
-    '짝수인 경우: 해당 숫자를 2로 나눕니다.\n' +
-    '홀수인 경우: 해당 숫자에 2를 곱하고 1을 더합니다.\n' +
-    '결과값이 10을 넘는 경우: 10을 뺍니다.';
-
-const constraints = [
-  '배열 numbers의 길이는 1 이상 100,000 이하입니다.',
-  '배열의 각 원소는 1 이상 100 이하의 자연수입니다.'
-];
-
+const props = defineProps({
+  content: {
+    type: String,
+    required: true
+  }
+});
 </script>
 
 <template>
@@ -19,16 +15,8 @@ const constraints = [
     <div class="description">
       <div class="problem-section">
         <div class="section-content">
-          {{ problemText }}
+          {{ props.content }}
         </div>
-      </div>
-      <div class="constraints-section">
-        <h3 class="constraints-title">제한사항</h3>
-        <ul class="constraints-list">
-          <li v-for="(constraint, index) in constraints" :key="index">
-            {{ constraint }}
-          </li>
-        </ul>
       </div>
     </div>
   </div>

--- a/frontend/src/router/codingroom.js
+++ b/frontend/src/router/codingroom.js
@@ -2,7 +2,7 @@ import CodingRoom from "@/views/codingroom/CodingRoom.vue";
 
 export default [
     {
-        path: '/codingroom',
+        path: '/codingroom/:codingRoomId/:problemId',
         component: CodingRoom
     }
 ];

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -133,9 +133,22 @@ watch(selectedLevel, () => {
   fetchProblemList();
 });
 
+const goToCodingRoom = (codingRoomId, problemId) => {
+  router.push({path:`/codingroom/${String(codingRoomId)}/${String(problemId)}`});
+};
+
 const handleProblemClick = async (problem) => {
   try {
-    console.log(problem.problemId);
+    const response = await axios.post(`http://localhost:8080/api/v1/codingroom/${problem.problemId}`, {} , {
+      headers: {
+        Authorization: `Bearer ${store.accessToken}`
+      }
+    });
+
+    const problemId = response.data.problemId;
+    const codingRoomId = response.data.codingRoomId;
+
+    goToCodingRoom(codingRoomId, problemId);
   } catch (error) {
     console.error('코딩방 생성 중 에러가 발생했습니다.', error.response ? error.response.data : error.message);
   }

--- a/frontend/src/views/codingroom/CodingRoom.vue
+++ b/frontend/src/views/codingroom/CodingRoom.vue
@@ -2,14 +2,57 @@
 import CodeEditor from "@/components/codingroom/CodeEditor.vue";
 import ProblemDescription from "@/components/codingroom/ProblemDescription.vue";
 import Chat from "@/components/codingroom/ChatArea.vue";
+
+import { useRoute } from 'vue-router';
+import {reactive, onMounted} from 'vue';
+import axios from "axios";
+import {useAuthStore} from "@/stores/auth.js";
+
+const route = useRoute();
+const codingRoomId = route.params.codingRoomId;
+const problemId = route.params.problemId;
+const useAuth = useAuthStore();
+
+
+// 조회한 문제 정보를 담을 객체
+const problemInfo = reactive({
+  problemId : 0,
+  title : '',
+  content : '',
+  problemLevel : ''
+});
+
+const authObjectInfo = {
+  userId : useAuth.userId,
+  accessToken : useAuth.accessToken,
+  refreshToken : useAuth.refreshToken
+}
+
+const fetchProblemInfo = async (problemId) => {
+  const response = await axios.get(`http://localhost:8080/api/v1/problem/${problemId}`, {
+    headers : {
+      Authorization: `Bearer ${authObjectInfo.accessToken}`
+    }
+  });
+
+  problemInfo.problemId = response.data.problemId;
+  problemInfo.title = response.data.title;
+  problemInfo.content = response.data.content;
+  problemInfo.problemLevel = response.data.problemLevel;
+}
+
+onMounted(async () => {
+  await fetchProblemInfo(problemId);
+});
+
 </script>
 
 <template>
   <div class="container">
     <div class="problem-container">
       <div class="content-wrapper">
-        <ProblemDescription/>
-        <Chat/>
+        <ProblemDescription :content="problemInfo.content" />
+        <Chat :codingRoomId="codingRoomId" />
       </div>
     </div>
     <div class="problem-container">


### PR DESCRIPTION
🌟개요
---
1. Home 화면에서 문제 목록 중 하나를 클릭하면 해당 코딩방으로 이동하는 기능 구현을 목적으로 한다.
2. 문제를 클릭하면 코딩방이 생성되며 이후 그 방으로 입장이 가능해야 한다.
3. 입장하면 문제 확인과 채팅, 코드 협업이 가능해야 한다.

🌐연결된 Issues
---
Closes #137

📋작업사항
---
1) 코딩방으로 들어가려면 방의 고유번호와 문제번호가 필요하게 됩니다 따라서 handleProblemClick 을 통해 codingRoomId, problmeId 를 받아오게 하여 문제를 해결했습니다. 이 과정에서 코딩방은 생성되어 DB에 저장됩니다.

2) goToCodingRoom 을 통해 codingRoomId, problemId 를 route로 넘겨주어 해당 컴포넌트가 필요한 정보를 넘겨주었습니다.

3) CodingRoom 컴포넌트 하위의 컴포넌트들에게 props 로 적절하게 데이터를 나누어 주도록 작업했습니다.

✏️작성한 이슈 외 작업사항
---

✅체크리스트
---
- [ ] PR 규칙을 준수하였는가?
- [ ] 이슈번호를 작성하였는가?
- [ ] 추가/수정 사항을 설명하였는가?
